### PR TITLE
orb: Bump circleci/docker from 0.5.18 to 0.5.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  docker: circleci/docker@0.5.18
+  docker: circleci/docker@0.5.19
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ workflows:
   test:
     jobs:
       - test
+      - orb-update
       - docker/publish:
           deploy: false
           image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN go build -a -installsuffix cgo -o orb-update
 FROM alpine:3.10
 COPY --from=builder /go/src/github.com/sawadashota/orb-update/orb-update /usr/bin/orb-update
 
-RUN apk add -U --no-cache ca-certificates
+RUN apk add -U --no-cache git openssh ca-certificates
 
 WORKDIR /repo
 


### PR DESCRIPTION
Bump circleci/docker from 0.5.18 to 0.5.19
https://circleci.com/orbs/registry/orb/circleci/docker