### PR TITLE
orb: Bump circleci/docker from 0.5.18 to 0.5.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  docker: circleci/docker@0.5.18
+  docker: circleci/docker@0.5.19
 
 jobs:
   test:


### PR DESCRIPTION
Bump circleci/docker from 0.5.18 to 0.5.19
https://circleci.com/orbs/registry/orb/circleci/docker