### PR TITLE
orb: Bump circleci/docker from 0.5.18 to 0.5.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  docker: circleci/docker@0.5.18
+  docker: circleci/docker@0.5.19
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .envrc
+.docker-env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.13-alpine AS builder
 WORKDIR /go/src/github.com/sawadashota/orb-update
 
+RUN apk add -U --no-cache ca-certificates
+
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on
 
 COPY . .
@@ -9,11 +11,11 @@ RUN go mod download
 RUN go mod verify
 RUN go build -a -installsuffix cgo -o orb-update
 
-FROM alpine:3.10
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/sawadashota/orb-update/orb-update /usr/bin/orb-update
 
-RUN apk add -U --no-cache git openssh ca-certificates
-
+USER 1000
 WORKDIR /repo
 
 CMD ["orb-update"]

--- a/pullrequest/git.go
+++ b/pullrequest/git.go
@@ -85,8 +85,10 @@ func (d *DefaultGitClient) SwitchBack() error {
 		return err
 	}
 
+	fmt.Printf("SwitchBack: %s", d.BaseBranch())
 	return w.Checkout(&git.CheckoutOptions{
 		Branch: plumbing.ReferenceName("refs/heads/" + d.BaseBranch()),
+		Force:  true,
 	})
 }
 


### PR DESCRIPTION
Bump circleci/docker from 0.5.18 to 0.5.19
https://circleci.com/orbs/registry/orb/circleci/docker