### PR TITLE
orb: Bump circleci/docker from 0.5.18 to 0.5.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   orb-update: sawadashota/orb-update@0.1.4
-  docker: circleci/docker@0.5.18
+  docker: circleci/docker@0.5.19
   orb-tools: circleci/orb-tools@8.27.6
   envsubst: sawadashota/envsubst@1.1.0
 


### PR DESCRIPTION
Bump circleci/docker from 0.5.18 to 0.5.19
https://circleci.com/orbs/registry/orb/circleci/docker