### PR TITLE
orb: Bump circleci/docker from 0.5.19 to 0.5.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   orb-update: sawadashota/orb-update@volatile
-  docker: circleci/docker@0.5.19
+  docker: circleci/docker@0.5.20
   orb-tools: circleci/orb-tools@9.0.0
   envsubst: sawadashota/envsubst@1.1.0
 


### PR DESCRIPTION
Bump circleci/docker from 0.5.19 to 0.5.20

https://circleci.com/orbs/registry/orb/circleci/docker