### PR TITLE
orb: Bump circleci/docker from 0.5.19 to 0.5.20

### DIFF
--- a/.circleci/test/config.yml
+++ b/.circleci/test/config.yml
@@ -3,6 +3,6 @@ version: 2.1
 orbs:
   orb-update: sawadashota/orb-update@0.1.8
   orb-update-alpha: sawadashota/orb-update@dev:alpha
-  docker: circleci/docker@0.5.19
+  docker: circleci/docker@0.5.20
   orb-tools: circleci/orb-tools@8.27.6
   envsubst: sawadashota/envsubst@volatile


### PR DESCRIPTION
Bump circleci/docker from 0.5.19 to 0.5.20

https://circleci.com/orbs/registry/orb/circleci/docker